### PR TITLE
Helm - fix warning for backend deployment

### DIFF
--- a/agora/contoso_hypermarket/README.md
+++ b/agora/contoso_hypermarket/README.md
@@ -21,6 +21,12 @@ kubectl apply -f ../cerebral_api/operations/cerebral-simulator.yaml
 kubectl apply -f ../cerebral_api/operations/cerebral-simulator-prometheus.yaml
 kubectl apply -f ../shopper_insights_api/operations/shopper-insights-prometheus.yaml
 
+## Re-installing
+
+If re-installing with Helm, the influxdb-pvc will not uninstall by itself without patching the finalizer (the default behavior protects against accidental deletion)
+kubectl patch pvc influxdb-pvc -p '{"metadata":{"finalizers":null}}'  
+kubectl delete pvc influxdb-pvc
+
 ### Deploy with yaml
 
 kubectl create ns contoso-hypermarket

--- a/agora/contoso_hypermarket/charts/main-ui-backend-db/templates/deployment.yaml
+++ b/agora/contoso_hypermarket/charts/main-ui-backend-db/templates/deployment.yaml
@@ -1,4 +1,3 @@
-Deployment:
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/agora/contoso_hypermarket/charts/main-ui-backend-db/templates/service.yaml
+++ b/agora/contoso_hypermarket/charts/main-ui-backend-db/templates/service.yaml
@@ -1,4 +1,3 @@
-Service:
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
There were two extra resource types at the top of deployment.yaml and service.yaml, resulting in a warning like: "W1031 15:18:50.137321 24443 warnings.go:70] unknown field "Service"". This PR fixes the warning.  In addition, the README has been updated to include steps to delete the influxdb-pvc for testing purposes.