### PR TITLE
Helm - add check for cerebral-api

### DIFF
--- a/agora/contoso_hypermarket/charts/agora-ui/templates/deployment.yaml
+++ b/agora/contoso_hypermarket/charts/agora-ui/templates/deployment.yaml
@@ -15,7 +15,16 @@ spec:
       initContainers:
       - name: init-backend-api-check
         image: mcr.microsoft.com/azurelinux/busybox:1.36
-        command: ['sh', '-c', 'until nc -z -v -w30 backend-api.contoso-hypermarket.svc.cluster.local 5002 && nc -z -v -w30 footfall-ai-api.contoso-hypermarket.svc.cluster.local 5000; do echo "Waiting for the backend-api and footfall-ai-api to start" && sleep 5; done']
+        command:
+          - sh
+          - -c
+          - |
+            until nc -z -v -w30 backend-api.contoso-hypermarket.svc.cluster.local 5002 && \
+                  nc -z -v -w30 footfall-ai-api.contoso-hypermarket.svc.cluster.local 5000 && \
+                  nc -z -v -w30 cerebral-api-service.contoso-hypermarket.svc.cluster.local 5003; do
+              echo "Waiting for the backend-api, footfall-ai-api, and cerebral-api-service to start"
+              sleep 5
+            done
       containers:
       - name: main-ui
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/agora/contoso_hypermarket/charts/contoso-hypermarket/Chart.yaml
+++ b/agora/contoso_hypermarket/charts/contoso-hypermarket/Chart.yaml
@@ -45,3 +45,6 @@ dependencies:
   - name: influxdb
     version: 0.1.0
     repository: "file://../influxdb"
+  - name: shopper-insights
+    version: 0.1.0
+    repository: "file://../shopper-insights"

--- a/agora/contoso_hypermarket/charts/rtsp/values.yaml
+++ b/agora/contoso_hypermarket/charts/rtsp/values.yaml
@@ -14,7 +14,7 @@ services:
     port: 8554
   zoom:
     type: LoadBalancer
-    port: 8554
+    port: 8555
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR:
- adds check for cerebral-api service for the main UI in the init-container
- corrects the rtsp zoom to use port 8555
- adds shopper-insights to the contoso-hypermarket chart