### PR TITLE
adding prom components to cerebral and shopper insights

### DIFF
--- a/agora/contoso_hypermarket/charts/cerebral-api/templates/cerebral-simulator-prometheus.yaml
+++ b/agora/contoso_hypermarket/charts/cerebral-api/templates/cerebral-simulator-prometheus.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cerebral-service-monitor
+  labels:
+    release: prometheus  
+spec:
+  endpoints:
+  - port: cerebral-metrics # Make sure this matches the port name of your service
+    interval: 30s
+    path: /metrics
+  selector:
+    matchLabels:
+      app: cerebral-simulator-service # Make sure this matches the label of your service

--- a/agora/contoso_hypermarket/charts/shopper-insights/templates/prometheus.yaml
+++ b/agora/contoso_hypermarket/charts/shopper-insights/templates/prometheus.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: shopper-insights-service-monitor
+  labels:
+    release: prometheus  
+spec:
+  endpoints:
+  - port: shopper-insights-metrics # Make sure this matches the port name of your service
+    interval: 30s
+    path: /metrics
+  selector:
+    matchLabels:
+      app: shopper-insights-service # Make sure this matches the label of your service


### PR DESCRIPTION
- this adds the prom components to cerebral and shopper insights
- it requires the prom-stack chart to have already been deployed.  I intentionally did not add that as a chart dependency (yet?) until we decide if we're deploying it separately