### PR TITLE
Add Orders and Inventory REST API endpoints ans STORE_ID

### DIFF
--- a/agora/cerebral_simulator/src/Dockerfile
+++ b/agora/cerebral_simulator/src/Dockerfile
@@ -61,6 +61,7 @@ ENV SQL_SERVER=your_server
 ENV SQL_DATABASE=RetailStore
 ENV SQL_USERNAME=your_username
 ENV SQL_PASSWORD=your_password
+ENV STORE_ID=SEA
 
 EXPOSE 8001
 

--- a/agora/cerebral_simulator/src/app.py
+++ b/agora/cerebral_simulator/src/app.py
@@ -17,7 +17,7 @@ from prometheus_client.core import CollectorRegistry
 from flask import Flask, Response, jsonify
 from flasgger import Swagger, swag_from
 
-from store_simulator import run_store_simulator
+from store_simulator import run_store_simulator, StoreSimulator, ProductInventory
 
 #dev mode
 #from dotenv import load_dotenv
@@ -43,7 +43,9 @@ ENABLE_HISTORICAL = os.getenv("ENABLE_HISTORICAL", "True").lower() == "true"
 ENABLE_PROMETHEUS = os.getenv("ENABLE_PROMETHEUS", "True").lower() == "true"
 ENABLE_API = os.getenv("ENABLE_API", "True").lower() == "true"
 ENABLE_STORE_SIMULATOR = os.getenv("ENABLE_STORE_SIMULATOR", "True").lower() == "true"
+STORE_ID = os.getenv("STORE_ID", "SEA")
 
+store_simulator_instance = None
 
 # Device Simulation Settings
 DEVICE_COUNTS = {
@@ -231,6 +233,7 @@ def publish_data_to_mqtt(equipment_type, device_id, timestamp, data):
     try:
         mqtt_payload = json.dumps({
             "timestamp": timestamp,
+            "store_id": STORE_ID,
             "device_id": device_id,
             "equipment_type": equipment_type,
             "data": data
@@ -491,6 +494,302 @@ app.config['SWAGGER'] = {
     'specs_route': '/apidocs/'
 }
 
+@app.route('/api/v1/orders/recent', methods=['GET'])
+@swag_from({
+    'responses': {
+        200: {
+            'description': 'List of recent orders',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'orders': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'timestamp': {'type': 'string', 'format': 'date-time'},
+                                'order_data': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'sale_id': {'type': 'string'},
+                                        'sale_date': {'type': 'string', 'format': 'date-time'},
+                                        'store_id': {'type': 'string'},
+                                        'store_city': {'type': 'string'},
+                                        'product_id': {'type': 'string'},
+                                        'product_name': {'type': 'string'},
+                                        'quantity': {'type': 'integer'},
+                                        'item_total': {'type': 'number'},
+                                        'payment_method': {'type': 'string'}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    'total_orders': {'type': 'integer'}
+                }
+            }
+        }
+    },
+    'summary': 'Returns the list of recent orders',
+    'tags': ['Orders']
+})
+def get_recent_orders():
+    if not store_simulator_instance:
+        return jsonify({'error': 'Store simulator not running'}), 503
+    
+    orders = store_simulator_instance.recent_orders
+    return jsonify({
+        'orders': orders,
+        'total_orders': len(orders)
+    })
+
+@app.route('/api/v1/orders/summary', methods=['GET'])
+@swag_from({
+    'responses': {
+        200: {
+            'description': 'Summary of recent orders',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'total_orders': {'type': 'integer'},
+                    'total_sales': {'type': 'number'},
+                    'average_order_value': {'type': 'number'},
+                    'orders_by_store': {
+                        'type': 'object',
+                        'additionalProperties': {'type': 'integer'}
+                    },
+                    'payment_methods': {
+                        'type': 'object',
+                        'additionalProperties': {'type': 'integer'}
+                    }
+                }
+            }
+        }
+    },
+    'summary': 'Returns a summary of recent orders',
+    'tags': ['Orders']
+})
+def get_orders_summary():
+    if not store_simulator_instance:
+        return jsonify({'error': 'Store simulator not running'}), 503
+    
+    orders = store_simulator_instance.recent_orders
+    if not orders:
+        return jsonify({
+            'total_orders': 0,
+            'total_sales': 0,
+            'average_order_value': 0,
+            'orders_by_store': {},
+            'payment_methods': {}
+        })
+
+    total_sales = 0
+    orders_by_store = {}
+    payment_methods = {}
+    
+    for order in orders:
+        order_data = order['order_data']
+        total_sales += float(order_data['item_total'])
+        
+        store_id = order_data['store_id']
+        orders_by_store[store_id] = orders_by_store.get(store_id, 0) + 1
+        
+        payment = order_data['payment_method']
+        payment_methods[payment] = payment_methods.get(payment, 0) + 1
+
+    return jsonify({
+        'total_orders': len(orders),
+        'total_sales': round(total_sales, 2),
+        'average_order_value': round(total_sales / len(orders), 2),
+        'orders_by_store': orders_by_store,
+        'payment_methods': payment_methods
+    })
+
+@app.route('/api/v1/inventory', methods=['GET'])
+@swag_from({
+    'responses': {
+        200: {
+            'description': 'Current inventory for all stores',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'inventory': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'store_id': {'type': 'string'},
+                                'product_id': {'type': 'string'},
+                                'in_stock': {'type': 'integer'},
+                                'retail_price': {'type': 'number'},
+                                'reorder_threshold': {'type': 'integer'},
+                                'last_restocked': {'type': 'string', 'format': 'date-time'},
+                                'date_time': {'type': 'string', 'format': 'date-time'}
+                            }
+                        }
+                    },
+                    'total_items': {'type': 'integer'}
+                }
+            }
+        }
+    },
+    'summary': 'Returns current inventory for all stores',
+    'tags': ['Inventory']
+})
+def get_inventory():
+    if not store_simulator_instance:
+        return jsonify({'error': 'Store simulator not running'}), 503
+    
+    inventory_list = []
+    for key, inventory in store_simulator_instance.current_inventory.items():
+        inventory_list.append({
+            'store_id': inventory.store_id,
+            'product_id': inventory.product_id,
+            'in_stock': inventory.in_stock,
+            'retail_price': float(inventory.retail_price),
+            'reorder_threshold': inventory.reorder_threshold,
+            'last_restocked': inventory.last_restocked.isoformat(),
+            'date_time': inventory.date_time.isoformat()
+        })
+    
+    return jsonify({
+        'inventory': inventory_list,
+        'total_items': len(inventory_list)
+    })
+
+@app.route('/api/v1/inventory/summary', methods=['GET'])
+@swag_from({
+    'responses': {
+        200: {
+            'description': 'Summary of current inventory',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'total_items': {'type': 'integer'},
+                    'items_by_store': {
+                        'type': 'object',
+                        'additionalProperties': {'type': 'integer'}
+                    },
+                    'low_stock_items': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'store_id': {'type': 'string'},
+                                'product_id': {'type': 'string'},
+                                'in_stock': {'type': 'integer'},
+                                'reorder_threshold': {'type': 'integer'}
+                            }
+                        }
+                    },
+                    'total_value': {'type': 'number'}
+                }
+            }
+        }
+    },
+    'summary': 'Returns a summary of current inventory status',
+    'tags': ['Inventory']
+})
+def get_inventory_summary():
+    if not store_simulator_instance:
+        return jsonify({'error': 'Store simulator not running'}), 503
+    
+    items_by_store = {}
+    low_stock_items = []
+    total_value = 0
+    
+    for key, inventory in store_simulator_instance.current_inventory.items():
+        # Count items by store
+        items_by_store[inventory.store_id] = items_by_store.get(inventory.store_id, 0) + inventory.in_stock
+        
+        # Calculate total value
+        total_value += inventory.in_stock * inventory.retail_price
+        
+        # Check for low stock
+        if inventory.in_stock <= inventory.reorder_threshold:
+            low_stock_items.append({
+                'store_id': inventory.store_id,
+                'product_id': inventory.product_id,
+                'in_stock': inventory.in_stock,
+                'reorder_threshold': inventory.reorder_threshold
+            })
+    
+    return jsonify({
+        'total_items': sum(items_by_store.values()),
+        'items_by_store': items_by_store,
+        'low_stock_items': low_stock_items,
+        'total_value': round(float(total_value), 2)
+    })
+
+@app.route('/api/v1/inventory/<store_id>', methods=['GET'])
+@swag_from({
+    'parameters': [
+        {
+            'name': 'store_id',
+            'in': 'path',
+            'type': 'string',
+            'required': True,
+            'description': 'Store identifier'
+        }
+    ],
+    'responses': {
+        200: {
+            'description': 'Inventory for specific store',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'store_id': {'type': 'string'},
+                    'items': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'product_id': {'type': 'string'},
+                                'in_stock': {'type': 'integer'},
+                                'retail_price': {'type': 'number'},
+                                'last_restocked': {'type': 'string', 'format': 'date-time'}
+                            }
+                        }
+                    },
+                    'total_items': {'type': 'integer'},
+                    'total_value': {'type': 'number'}
+                }
+            }
+        },
+        404: {
+            'description': 'Store not found'
+        }
+    },
+    'summary': 'Get inventory for a specific store',
+    'tags': ['Inventory']
+})
+def get_store_inventory(store_id):
+    if not store_simulator_instance:
+        return jsonify({'error': 'Store simulator not running'}), 503
+    
+    store_inventory = []
+    total_value = 0
+    
+    for key, inventory in store_simulator_instance.current_inventory.items():
+        if inventory.store_id == store_id:
+            store_inventory.append({
+                'product_id': inventory.product_id,
+                'in_stock': inventory.in_stock,
+                'retail_price': float(inventory.retail_price),
+                'last_restocked': inventory.last_restocked.isoformat()
+            })
+            total_value += inventory.in_stock * inventory.retail_price
+    
+    if not store_inventory:
+        return jsonify({'error': 'Store not found'}), 404
+    
+    return jsonify({
+        'store_id': store_id,
+        'items': store_inventory,
+        'total_items': sum(item['in_stock'] for item in store_inventory),
+        'total_value': round(float(total_value), 2)
+    })
+
 # Connect to InfluxDB
 client = InfluxDBClient(url=INFLUXDB_URL, token=INFLUXDB_TOKEN, org=INFLUXDB_ORG)
 write_api = client.write_api(write_options=SYNCHRONOUS)
@@ -510,9 +809,14 @@ if __name__ == "__main__":
 
     # Start store simulator in a separate thread
     if ENABLE_STORE_SIMULATOR:
-        store_simulator_thread = Thread(target=run_store_simulator, daemon=True)
+        simulator = StoreSimulator()
+        store_simulator_instance = simulator
+        store_simulator_thread = Thread(target=simulator.run, daemon=True)
         store_simulator_thread.start()
         logger.info("Store simulator started")
+        #store_simulator_thread = Thread(target=run_store_simulator, daemon=True)
+        #store_simulator_thread.start()
+        #logger.info("Store simulator started")
 
     if ENABLE_MQTT:
         try:

--- a/agora/cerebral_simulator/src/store_simulator.py
+++ b/agora/cerebral_simulator/src/store_simulator.py
@@ -10,7 +10,7 @@ import paho.mqtt.client as mqtt
 import pyodbc
 
 #DevMode
-from dotenv import load_dotenv
+#from dotenv import load_dotenv
 
 class PriceRange:
     def __init__(self, min, max):
@@ -120,6 +120,17 @@ class StoreSimulator:
 
         self.products_list = []
         self.current_inventory = {}
+
+        # Add orders storage
+        self.recent_orders = []
+        self.max_orders_history = 100
+
+    def add_order(self, order_data):
+        """Add order to recent orders list"""
+        self.recent_orders.append(order_data)
+        # keep only the recent orders
+        if len(self.recent_orders) > self.max_orders_history:
+            self.recent_orders.pop(0)
 
     def init_database(self):
         """Initialize database connection and create tables if they don't exist"""
@@ -444,6 +455,12 @@ class StoreSimulator:
                                 'customer_id': f'C-{random.randint(1,1000):03d}',
                                 'register_id': random.choice(self.store_registers)
                             }
+
+                            # Add to recent orders
+                            self.add_order({
+                                "timestamp": current_time_str,
+                                "order_data": line_item
+                            })
 
                             # Save to SQL if enabled
                             if self.ENABLE_SQL:


### PR DESCRIPTION
- Add /api/v1/orders/recent and /orders/summary endpoints
- Add /api/v1/inventory, /inventory/summary endpoints
- Add store-specific inventory endpoint /inventory/{store_id}
- Add Swagger documentation for new endpoints
- Implement data persistence for orders history
- STORE_ID