### PR TITLE
add init-check for mssql

### DIFF
--- a/agora/contoso_hypermarket/charts/cerebral-api/templates/cerebral-simulator.yaml
+++ b/agora/contoso_hypermarket/charts/cerebral-api/templates/cerebral-simulator.yaml
@@ -52,6 +52,17 @@ spec:
       labels:
         app: cerebral-simulator
     spec:
+      initContainers:
+      - name: init-sql-check
+        image: mcr.microsoft.com/azurelinux/busybox:1.36
+        command:
+          - sh
+          - -c
+          - |
+            until nc -z -v -w30 mssql-service.contoso-hypermarket.svc.cluster.local 1433; do
+              echo "Waiting for the mssql-service to start"
+              sleep 5
+            done
       containers:
       - name: cerebral-simulator
         ports:


### PR DESCRIPTION
checks for the mssql service to be accessible on port 1433 before starting cerebral-simulator container