### PR TITLE
remove duplicate env section

### DIFF
--- a/agora/contoso_hypermarket/charts/cerebral-api/templates/cerebral-simulator.yaml
+++ b/agora/contoso_hypermarket/charts/cerebral-api/templates/cerebral-simulator.yaml
@@ -103,7 +103,6 @@ spec:
             secretKeyRef:
               name: azure-eventhub-secret
               key: azure-eventhub-connection-string
-        env:
         - name: SQL_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
I had a duplicate env section for the simulator, causing GitOps to fail