### PR TITLE
read from k8s secret and use MCR InfluxDB

### DIFF
--- a/agora/contoso_motors/charts/influxdb/templates/influxdb-import-dashboard.yaml
+++ b/agora/contoso_motors/charts/influxdb/templates/influxdb-import-dashboard.yaml
@@ -19,7 +19,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: influxdb-import-dashboard-01
-          image: influxdb:latest
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - influx
           args:
@@ -63,7 +64,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: influxdb-import-dashboard-02
-          image: influxdb:latest
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - influx
           args:
@@ -108,7 +110,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: influxdb-import-dashboard-03
-          image: influxdb:latest
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - influx
           args:

--- a/agora/contoso_motors/charts/influxdb/templates/influxdb-setup.yaml
+++ b/agora/contoso_motors/charts/influxdb/templates/influxdb-setup.yaml
@@ -17,15 +17,17 @@ spec:
     spec:
       containers:
       - name: bash-job
-        image: influxdb:latest
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/bash", "-c"]
         args:
         - |
           #!/bin/bash
-
+        
+          sleep 5
           # Run the influx setup command and capture any output and error
-          output=$(influx setup --host http://influxdb.contoso-motors.svc.cluster.local:8086 --bucket manufacturing --org InfluxData --password ArcPassword123!! --username admin --token secret-token --force 2>&1)
-
+          output=$(influx setup --host http://influxdb.contoso-motors.svc.cluster.local:8086 --bucket manufacturing --org InfluxData --password $(cat /etc/secrets/password) --username admin --token secret-token --force 2>&1)
+          
           # If the command was successful, print the output and exit
           if [ $? -eq 0 ]; then
             echo "$output"
@@ -41,5 +43,14 @@ spec:
             echo "$output"
             exit 1
           fi
+          
+        volumeMounts:
+          - name: influxdb
+            mountPath: /etc/secrets
+            readOnly: true
+      volumes:
+        - name: influxdb
+          secret:
+            secretName: influxdb-pass
       restartPolicy: Never
-  backoffLimit: 4
+

--- a/agora/contoso_motors/charts/influxdb/templates/influxdb.yaml
+++ b/agora/contoso_motors/charts/influxdb/templates/influxdb.yaml
@@ -161,7 +161,8 @@ spec:
       serviceAccount: contosoba    
       containers:
       - name: influxdb
-        image: influxdb:latest
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
           limits:
             memory: "2Gi"

--- a/agora/contoso_motors/charts/influxdb/values.yaml
+++ b/agora/contoso_motors/charts/influxdb/values.yaml
@@ -3,3 +3,8 @@
 # Declare variables to be passed into your templates.
 
 influxDBEndpoint: "http://influxdb.contoso-motors.svc.cluster.local:8086"
+influxPasswordSecret: influxdb-pass
+image:
+  repository: mcr.microsoft.com/azurelinux/base/influxdb
+  pullPolicy: IfNotPresent
+  tag: "2.7"


### PR DESCRIPTION
This PR updates the InfluxDB chart to pull InfluxDB from the Microsoft Container Registry (MCR) instead of Docker Hub.  In addition, it updates the chart to read the InfluxDB password from a Kubernetes secret.